### PR TITLE
Prototyping player manager

### DIFF
--- a/Assets/Gameplay.meta
+++ b/Assets/Gameplay.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d89fc2a8b16649d4895c3bae96523567
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gameplay/ManagerBase.cs
+++ b/Assets/Gameplay/ManagerBase.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+//TODO: proper namespace?
+//namespace Assets.Gameplay
+//{
+public class ManagerBase<T> : MonoBehaviour where T: Component
+{
+    static T _instance = null;
+
+    public static T Instance 
+    {
+        get
+        {
+            if (_instance == null) _instance = FindObjectOfType<T>();
+
+            return _instance;
+        }
+    }
+}
+//}

--- a/Assets/Gameplay/ManagerBase.cs.meta
+++ b/Assets/Gameplay/ManagerBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad6a7ffd8792c734893c4f4e8f0c4323
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gameplay/Player.cs
+++ b/Assets/Gameplay/Player.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using TMPro;
+using UnityEngine;
+//TODO: proper namespace?
+//namespace Assets.Gameplay
+//{
+public class Player : MonoBehaviour
+{
+    [SerializeField]
+    SpriteRenderer _spriteRenderer = null;
+
+    [SerializeField]
+    TextMeshPro _displayNameRenderer = null;
+    
+    /// <summary>
+    /// will be called at Player.OnDestroy unity event
+    /// </summary>
+    public event Action<Player> onDestroy;
+    
+    /// <summary>
+    /// sets name rendered on top of player sprite
+    /// </summary>
+    public string displayName
+    {
+        get => _displayNameRenderer.text;
+        set => _displayNameRenderer.text = value;
+    }
+
+    /// <summary>
+    /// store random value for wave animation purposes
+    /// </summary>
+    float _wavingRng = 0;
+
+    private void Awake()
+    {
+        _wavingRng = UnityEngine.Random.Range(0.00001f, 0.00005f);
+    }
+
+    private void Update()
+    {
+        
+    }
+
+    private void LateUpdate()
+    {
+        //simple wave animation
+        transform.position += new Vector3(Mathf.Sin(Time.time) * (0.00001f + _wavingRng), Mathf.Sin(Time.time) * (_wavingRng + 0.0001f), 0);
+    }
+
+    private void OnDestroy()
+    {
+        onDestroy?.Invoke(this);
+    }
+}
+//}

--- a/Assets/Gameplay/Player.cs.meta
+++ b/Assets/Gameplay/Player.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7e1e0b323400144c91f9aa7202b4b99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Gameplay/PlayerManager.cs
+++ b/Assets/Gameplay/PlayerManager.cs
@@ -55,9 +55,13 @@ public class PlayerManager : ManagerBase<PlayerManager>
     /// </summary>
     /// <param name="playerName">name to display on top of the player sprite</param>
     /// <param name="position">position to spawn player at</param>
-    /// <returns>instance of the player</returns>
+    /// <returns>instance of the player, can only create 1 player per playerName</returns>
     public Player Spawn(string playerName, Vector2 position)
     {
+        //TODO: only allow 1 player instance?
+        var existingPlayer = FindPlayerByName(playerName);
+        if (existingPlayer != null) return null;
+
         //create instance of player prefab at position
         var instance = Instantiate(_playerPrefab, position, Quaternion.identity);
         //set instance player name to display
@@ -78,7 +82,7 @@ public class PlayerManager : ManagerBase<PlayerManager>
     /// Spawns a player at default spawnzone
     /// </summary>
     /// <param name="playerName">name to display on top of the player sprite</param>
-    /// <returns>instance of the player</returns>
+    /// <returns>instance of the player, can only create 1 player per playerName</returns>
     public Player Spawn(string playerName)
     {
         //TODO: make sure that players dont spawn too near each other?

--- a/Assets/Gameplay/PlayerManager.cs
+++ b/Assets/Gameplay/PlayerManager.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+//TODO: proper namespace?
+//namespace Assets.Gameplay
+//{
+
+/// <summary>
+/// A class to manage player instances
+/// </summary>
+public class PlayerManager : ManagerBase<PlayerManager>
+{
+    [SerializeField]
+    Transform _spawnZoneTransform = null;
+    //TODO: multiple player prefabs?
+    [SerializeField]
+    Player _playerPrefab = null;
+
+    List<Player> _players = new List<Player>();
+
+    private void Awake()
+    {
+        //for editor... making sure we start off with a clean list of players
+        _players = new List<Player>();
+        
+        /*
+        for (int i = 0; i < 10; i++)
+        {
+            Spawn("HORN COOM", GetRandomSpawnPosition());
+
+        }*/
+    }
+
+    /// <summary>
+    /// Gets a random spawn position relative to the _spawnZoneTransform
+    /// </summary>
+    /// <returns></returns>
+    public Vector2 GetRandomSpawnPosition()
+    {
+        //read spawnzone bounds
+        var scaleX = _spawnZoneTransform.transform.localScale.x;
+        var scaleY = _spawnZoneTransform.transform.localScale.y;
+        //rng       
+        var x = UnityEngine.Random.Range(-scaleX / 2, scaleX / 2);
+        var y = UnityEngine.Random.Range(1, 1+(scaleY / 2));
+
+        return _spawnZoneTransform.position + new Vector3(x, y);
+    }
+
+    /// <summary>
+    /// Spawns a player
+    /// </summary>
+    /// <param name="playerName">name to display on top of the player sprite</param>
+    /// <param name="position">position to spawn player at</param>
+    /// <returns>instance of the player</returns>
+    public Player Spawn(string playerName, Vector2 position)
+    {
+        //create instance of player prefab at position
+        var instance = Instantiate(_playerPrefab, position, Quaternion.identity);
+        //set instance player name to display
+        instance.displayName = playerName;
+      
+        //register ondestroy hook that will stop tracking the player in the _players list
+        instance.onDestroy += (self) => {
+            _players.Remove(self);
+        };
+
+        //start tracking player instance
+        _players.Add(instance);
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Spawns a player at default spawnzone
+    /// </summary>
+    /// <param name="playerName">name to display on top of the player sprite</param>
+    /// <returns>instance of the player</returns>
+    public Player Spawn(string playerName)
+    {
+        //TODO: make sure that players dont spawn too near each other?
+        return Spawn(playerName, GetRandomSpawnPosition());
+    }
+
+    [ContextMenu("Spawn player")]
+    void SpawnDebug()
+    {
+        Spawn("Player "+UnityEngine.Random.Range(0, float.MaxValue), GetRandomSpawnPosition());
+    }
+
+    [ContextMenu("Spawn 10 players")]
+    void Spawn10Debug()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            SpawnDebug();
+        }
+    }
+
+    //TODO: maybe store players in dictionary for faster search access?
+    public Player FindPlayerByName(string name)
+    {
+        return _players.FirstOrDefault(x => x.displayName.ToLower() == name.ToLower());
+    }
+}
+//}

--- a/Assets/Gameplay/PlayerManager.cs.meta
+++ b/Assets/Gameplay/PlayerManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b629de2971d9642459c45f52cd955e49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e2f8ebb65b05de4683fca995f315da8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,0 +1,272 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4581969212485155847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3165837528884660998}
+  - component: {fileID: 88389373904422286}
+  - component: {fileID: 19011845196709209}
+  m_Layer: 0
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3165837528884660998
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581969212485155847}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 870691608147937535}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.0123, y: 1.4705}
+  m_SizeDelta: {x: 2.4497, y: 1.3785}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &88389373904422286
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581969212485155847}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &19011845196709209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4581969212485155847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: U.S.S Horn Coom
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 3
+  m_fontSizeBase: 3
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 88389373904422286}
+  m_maskType: 0
+--- !u!1 &8400686001726078934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 870691608147937535}
+  - component: {fileID: 5873094681486359959}
+  - component: {fileID: 5224764213792697089}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &870691608147937535
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400686001726078934}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children:
+  - {fileID: 3165837528884660998}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5873094681486359959
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400686001726078934}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -251888383
+  m_SortingLayer: 1
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 96c68716fb0c66d4a9d49e2189717233, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &5224764213792697089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8400686001726078934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7e1e0b323400144c91f9aa7202b4b99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _spriteRenderer: {fileID: 5873094681486359959}
+  _displayNameRenderer: {fileID: 19011845196709209}

--- a/Assets/Prefabs/Player.prefab.meta
+++ b/Assets/Prefabs/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76a7ce4294c4baf4c83565174f2d5dfd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -147,11 +147,12 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 50107305}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3a0f1342f2441fa4695b6963043df6b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _channelToConnectTo: irishjohngames
 --- !u!4 &50107307
 Transform:
   m_ObjectHideFlags: 0
@@ -248,6 +249,148 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1093829817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1093829818}
+  - component: {fileID: 1093829821}
+  - component: {fileID: 1093829820}
+  - component: {fileID: 1093829819}
+  m_Layer: 0
+  m_Name: SpawnZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1093829818
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093829817}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -4.5, z: 0}
+  m_LocalScale: {x: 20, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1108825645}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1093829819
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093829817}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1093829820
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093829817}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1093829821
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093829817}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1108825643
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1108825645}
+  - component: {fileID: 1108825644}
+  m_Layer: 0
+  m_Name: PlayerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1108825644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108825643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b629de2971d9642459c45f52cd955e49, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _spawnZoneTransform: {fileID: 1093829818}
+  _playerPrefab: {fileID: 5224764213792697089, guid: 76a7ce4294c4baf4c83565174f2d5dfd, type: 3}
+--- !u!4 &1108825645
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108825643}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1093829818}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1677949801
 GameObject:

--- a/Assets/TwitchLibCtrl.cs
+++ b/Assets/TwitchLibCtrl.cs
@@ -56,6 +56,7 @@ namespace CoreTwitchLibSetup
 		private void OnChannelPointsReceived(object sender, TwitchLib.PubSub.Events.OnChannelPointsRewardRedeemedArgs e)
 		{
 			Debug.Log("Redemption: " + e.RewardRedeemed.Redemption.Reward.Title + " " + e.RewardRedeemed.Redemption.User.DisplayName + " " + e.RewardRedeemed.Redemption.Status);
+		
 		}
 
 		private void OnListenResponse(object sender, OnListenResponseArgs e)
@@ -84,6 +85,10 @@ namespace CoreTwitchLibSetup
 				case "hello":
 				case "ahoy":
 					_client.SendMessage(e.Command.ChatMessage.Channel, $"Ahoy {e.Command.ChatMessage.DisplayName}!");
+
+					//example of how to spawn a player 
+					PlayerManager.Instance.Spawn(e.Command.ChatMessage.DisplayName);
+
 					break;
 				case "about":
 					_client.SendMessage(e.Command.ChatMessage.Channel, "I be a Twitch bot running on the TwitchLib vessel!");

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -41,3 +41,9 @@ TagManager:
   - name: Default
     uniqueID: 0
     locked: 0
+  - name: Players
+    uniqueID: 4043078913
+    locked: 0
+  - name: Fx
+    uniqueID: 233418273
+    locked: 0

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -8,6 +8,9 @@ EditorUserSettings:
     RecentlyUsedScenePath-0:
       value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
       flags: 0
+    RecentlyUsedScenePath-1:
+      value: 22424703114646680e0b0227036c52111f19563f22213229
+      flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650
       flags: 0


### PR DESCRIPTION
- Add ability to spawn players through PlayerManager, after a player has been spawned they will be tracked on a list that would be used to find targets when the game is playing
- The default spawn location for players is at the bottom at the screen as defined in the design "doc" "Bottom of the screen chillin, until battle starts"
- Using MonoBehaviours for simplicity sake, easy to use, would rather not overengineer this stuff
- Players are simple SpriteRenderers with text being rendered on top of them (player name)